### PR TITLE
Use generic-deriving for compatibility

### DIFF
--- a/QuickCheck.cabal
+++ b/QuickCheck.cabal
@@ -77,13 +77,6 @@ library
   else
     cpp-options: -DNO_TEMPLATE_HASKELL
 
-  -- The new generics appeared in GHC 7.2...
-  if impl(ghc < 7.2)
-    cpp-options: -DNO_GENERICS
-  -- ...but in 7.2-7.4 it lives in the ghc-prim package.
-  if impl(ghc >= 7.2) && impl(ghc < 7.6)
-    Build-depends: ghc-prim
-
   -- Safe Haskell appeared in GHC 7.2, but GHC.Generics isn't safe until 7.4.
   if impl (ghc < 7.4)
     cpp-options: -DNO_SAFE_HASKELL
@@ -103,10 +96,15 @@ library
 
   if impl(ghc)
     -- 'Data.List.NonEmpty' is available in base only since GHC 8.0 / base 4.9
+    --
+    -- We use the generic-deriving library for GHC generics compatibility with
+    -- older versions of GHC (back to 7.0). It also backports the
+    -- representation types for unlifted types (UChar, UDouble, etc.) for GHCs
+    -- older than 8.0.
     if impl(ghc < 8.0)
-      build-depends: semigroups >=0.9
+      build-depends: semigroups >=0.9, generic-deriving >= 1.10.1
   else
-      cpp-options: -DNO_NONEMPTY
+      cpp-options: -DNO_NONEMPTY -DNO_GENERICS
 
   -- Switch off most optional features on non-GHC systems.
   if !impl(ghc)

--- a/Test/QuickCheck.hs
+++ b/Test/QuickCheck.hs
@@ -137,6 +137,7 @@ module Test.QuickCheck
   , arbitraryBoundedEnum
     -- ** Helper functions for implementing shrink
 #ifndef NO_GENERICS
+  , genericArbitrary
   , genericCoarbitrary
   , genericShrink
   , subterms

--- a/Test/QuickCheck/Function.hs
+++ b/Test/QuickCheck/Function.hs
@@ -5,7 +5,10 @@
 #endif
 
 #ifndef NO_GENERICS
-{-# LANGUAGE DefaultSignatures, FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE DefaultSignatures #-}
+#endif
 #endif
 
 -- | Generation of random shrinkable, showable functions.
@@ -77,7 +80,11 @@ import Data.List.NonEmpty(NonEmpty(..))
 #endif
 
 #ifndef NO_GENERICS
+#if MIN_VERSION_base(4,9,0)
 import GHC.Generics hiding (C)
+#else
+import Generics.Deriving.Base hiding (C)
+#endif
 #endif
 
 --------------------------------------------------------------------------
@@ -137,7 +144,7 @@ table (Map _ h p) = [ (h x, c) | (x,c) <- table p ]
 
 class Function a where
   function :: (a->b) -> (a:->b)
-#ifndef NO_GENERICS
+#if !defined(NO_GENERICS) && __GLASGOW_HASKELL__ >= 702
   default function :: (Generic a, GFunction (Rep a)) => (a->b) -> (a:->b)
   function = genericFunction
 #endif


### PR DESCRIPTION
Implements the changes I suggested in https://github.com/nick8325/quickcheck/pull/112. This uses the `generic-deriving` compatibility package to achieve the following:
1. Allow GHC generics support on GHC 7.0.
2. Enable generic support for datatypes with unlifted argument types.

This also reexports `genericArbitrary` from `Test.QuickCheck` for consistency with the other generic functions.
